### PR TITLE
3차 PR - OAuth 로그인을 위한 세팅 및 GitHub OAuth 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Other ###
+**/TestAnything.java
+**/oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// @ConfigurationProperties
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jpaplayground/JpaPlaygroundApplication.java
+++ b/src/main/java/com/jpaplayground/JpaPlaygroundApplication.java
@@ -2,8 +2,10 @@ package com.jpaplayground;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class JpaPlaygroundApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jpaplayground/domain/conversation/Conversation.java
+++ b/src/main/java/com/jpaplayground/domain/conversation/Conversation.java
@@ -11,11 +11,11 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Conversation {
 
 	@Id

--- a/src/main/java/com/jpaplayground/domain/product/Product.java
+++ b/src/main/java/com/jpaplayground/domain/product/Product.java
@@ -7,11 +7,11 @@ import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product {
 
 	@Id

--- a/src/main/java/com/jpaplayground/global/WebConfig.java
+++ b/src/main/java/com/jpaplayground/global/WebConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -23,4 +24,8 @@ public class WebConfig implements WebMvcConfigurer {
 		return filterRegistrationBean;
 	}
 
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
 }

--- a/src/main/java/com/jpaplayground/global/WebConfig.java
+++ b/src/main/java/com/jpaplayground/global/WebConfig.java
@@ -1,0 +1,26 @@
+package com.jpaplayground.global;
+
+import com.jpaplayground.global.oauth.LoginFilter;
+import javax.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final LoginFilter loginFilter;
+
+	@Bean
+	public FilterRegistrationBean<Filter> setFilterRegistration() {
+		FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+		filterRegistrationBean.setFilter(loginFilter);
+		filterRegistrationBean.addUrlPatterns("/login/github", "/login/naver", "/login/kakao");
+		filterRegistrationBean.setOrder(0);
+		return filterRegistrationBean;
+	}
+
+}

--- a/src/main/java/com/jpaplayground/global/exception/ErrorCode.java
+++ b/src/main/java/com/jpaplayground/global/exception/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
 
 	ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "Entity not found"),
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Invalid input value"),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+	OAUTH_SERVER_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth server not found");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/jpaplayground/global/member/Member.java
+++ b/src/main/java/com/jpaplayground/global/member/Member.java
@@ -1,0 +1,38 @@
+package com.jpaplayground.global.member;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String account;
+	private String name;
+	private String email;
+
+	@Builder
+	private Member(String account, String name, String email) {
+		this.account = account;
+		this.name = name;
+		this.email = email;
+	}
+
+	public static Member of(String account, String name, String email) {
+		return Member.builder()
+			.account(account)
+			.name(name)
+			.email(email)
+			.build();
+	}
+}

--- a/src/main/java/com/jpaplayground/global/member/MemberRepository.java
+++ b/src/main/java/com/jpaplayground/global/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.jpaplayground.global.member;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface MemberRepository extends CrudRepository<Member, Long> {
+
+}

--- a/src/main/java/com/jpaplayground/global/oauth/GitHubService.java
+++ b/src/main/java/com/jpaplayground/global/oauth/GitHubService.java
@@ -1,0 +1,80 @@
+package com.jpaplayground.global.oauth;
+
+import com.jpaplayground.global.member.Member;
+import com.jpaplayground.global.member.MemberRepository;
+import com.jpaplayground.global.oauth.dto.GitHubAccessToken;
+import com.jpaplayground.global.oauth.dto.GitHubUserInfo;
+import com.jpaplayground.global.oauth.dto.GithubAccessTokenRequest;
+import com.jpaplayground.global.oauth.dto.OAuthUserInfo;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class GitHubService {
+
+	private static final Pattern serviceNamePattern = Pattern.compile("(.*)Service$");
+	private final OAuthPropertyHandler oAuthPropertyHandler;
+	private final RestTemplate restTemplate;
+	private final MemberRepository memberRepository;
+	private OAuthProperties oAuthProperties; /* TODO : 생성자에서 초기화 할 시, SpringBootTest를 돌리면 초기화가 안되는 문제 무엇? */
+
+	@Autowired
+	public GitHubService(OAuthPropertyHandler oAuthPropertyHandler, RestTemplate restTemplate,
+		MemberRepository memberRepository) {
+		this.oAuthPropertyHandler = oAuthPropertyHandler;
+		this.restTemplate = restTemplate;
+		this.memberRepository = memberRepository;
+	}
+
+	public Member login(String code) {
+		oAuthProperties = oAuthPropertyHandler.getProperties(getOAuthServer());
+
+		GitHubAccessToken accessToken = getAccessToken(code);
+		log.debug("github access token : {}", accessToken.getAccessToken());
+		OAuthUserInfo userInfo = getUserInfo(accessToken);
+		log.debug("github user info : {}", userInfo);
+
+		return memberRepository.save(userInfo.toEntity());
+	}
+
+	private GitHubAccessToken getAccessToken(String code) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+		HttpEntity<GithubAccessTokenRequest> requestHttpEntity = new HttpEntity<>(
+			new GithubAccessTokenRequest(code, oAuthProperties), headers);
+
+		return restTemplate.postForObject(oAuthProperties.getAccessTokenRequestUrl()
+			, requestHttpEntity, GitHubAccessToken.class);
+	}
+
+	private OAuthUserInfo getUserInfo(GitHubAccessToken accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(accessToken.getAccessToken());
+
+		HttpEntity<Object> requestHttpEntity = new HttpEntity<>(headers);
+
+		return restTemplate.exchange(oAuthProperties.getUserInfoRequestUrl(),
+			HttpMethod.GET, requestHttpEntity, GitHubUserInfo.class).getBody();
+	}
+
+	/* TODO : 인터페이스에서 default 메서드로 만들기 */
+	private OAuthServer getOAuthServer() {
+		Matcher matcher = serviceNamePattern.matcher(this.getClass().getSimpleName());
+		if (matcher.find()) {
+			String server = matcher.group(1).toLowerCase();
+			return OAuthServer.getOAuthServer(server);
+		}
+		throw new OAuthServerNotFoundException();
+	}
+}

--- a/src/main/java/com/jpaplayground/global/oauth/LoginFilter.java
+++ b/src/main/java/com/jpaplayground/global/oauth/LoginFilter.java
@@ -1,0 +1,48 @@
+package com.jpaplayground.global.oauth;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginFilter implements Filter {
+
+	private static final Pattern pattern = Pattern.compile("/login/(.*)$");
+	private final OAuthPropertyHandler oAuthPropertyHandler;
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+		throws IOException {
+		HttpServletRequest request = (HttpServletRequest) servletRequest;
+		HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+		OAuthServer oAuthServer = OAuthServer.getOAuthServer(parseProvider(request));
+		log.debug("Login request to OAuth server : {}", oAuthServer.toString());
+		OAuthProperties properties = oAuthPropertyHandler.getProperties(oAuthServer)
+			.orElseThrow(
+				OAuthServerNotFoundException::new); /* TODO: Filter에서 발생한 에러는 ControllerAdvice에서 잡지 못한다. 그럼 어떡하지? */
+
+		response.sendRedirect(properties.getAccessCodeRequestUrl());
+	}
+
+	private String parseProvider(HttpServletRequest httpRequest) {
+		Matcher matcher = pattern.matcher(httpRequest.getRequestURI());
+
+		if (matcher.find()) {
+			return matcher.group(1);
+		}
+		throw new IllegalArgumentException();
+	}
+
+}

--- a/src/main/java/com/jpaplayground/global/oauth/LoginFilter.java
+++ b/src/main/java/com/jpaplayground/global/oauth/LoginFilter.java
@@ -29,9 +29,7 @@ public class LoginFilter implements Filter {
 
 		OAuthServer oAuthServer = OAuthServer.getOAuthServer(parseProvider(request));
 		log.debug("Login request to OAuth server : {}", oAuthServer.toString());
-		OAuthProperties properties = oAuthPropertyHandler.getProperties(oAuthServer)
-			.orElseThrow(
-				OAuthServerNotFoundException::new); /* TODO: Filter에서 발생한 에러는 ControllerAdvice에서 잡지 못한다. 그럼 어떡하지? */
+		OAuthProperties properties = oAuthPropertyHandler.getProperties(oAuthServer);
 
 		response.sendRedirect(properties.getAccessCodeRequestUrl());
 	}

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthController.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthController.java
@@ -1,0 +1,25 @@
+package com.jpaplayground.global.oauth;
+
+import com.jpaplayground.global.member.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthController {
+
+	/* TODO: OAuthService 인터페이스로 확장하기 */
+	private final GitHubService gitHubService;
+
+	@GetMapping("login/github/callback")
+	public void login(String code) {
+
+		log.debug("OAuth code received: {}", code);
+
+		Member member = gitHubService.login(code);
+		/* Todo: JWT 토큰 생성, 로그인 사용자 검증(Interceptor), 캐싱(redis? encache?) */
+	}
+}

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthProperties.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthProperties.java
@@ -1,0 +1,15 @@
+package com.jpaplayground.global.oauth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class OAuthProperties {
+
+	private final String clientId;
+	private final String clientSecret;
+	private final String accessCodeRequestUrl;
+	private final String redirectUri;
+
+}

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthProperties.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthProperties.java
@@ -10,6 +10,7 @@ public class OAuthProperties {
 	private final String clientId;
 	private final String clientSecret;
 	private final String accessCodeRequestUrl;
+	private final String accessTokenRequestUrl;
 	private final String redirectUri;
 
 }

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthProperties.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthProperties.java
@@ -9,8 +9,9 @@ public class OAuthProperties {
 
 	private final String clientId;
 	private final String clientSecret;
+	private final String redirectUri;
 	private final String accessCodeRequestUrl;
 	private final String accessTokenRequestUrl;
-	private final String redirectUri;
+	private final String userInfoRequestUrl;
 
 }

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthPropertyHandler.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthPropertyHandler.java
@@ -1,0 +1,22 @@
+package com.jpaplayground.global.oauth;
+
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@ConstructorBinding
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "oauth")
+public class OAuthPropertyHandler {
+
+	/* TODO : yml 파일의 "github"가 자동으로 Enum으로 매핑된다. HOW? */
+	private final Map<OAuthServer, OAuthProperties> server;
+
+	public OAuthProperties getProperties(OAuthServer oAuthServer) {
+		return server.get(oAuthServer);
+	}
+
+}

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthPropertyHandler.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthPropertyHandler.java
@@ -1,6 +1,7 @@
 package com.jpaplayground.global.oauth;
 
 import java.util.Map;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -15,8 +16,8 @@ public class OAuthPropertyHandler {
 	/* TODO : yml 파일의 "github"가 자동으로 Enum으로 매핑된다. HOW? */
 	private final Map<OAuthServer, OAuthProperties> server;
 
-	public OAuthProperties getProperties(OAuthServer oAuthServer) {
-		return server.get(oAuthServer);
+	public Optional<OAuthProperties> getProperties(OAuthServer oAuthServer) {
+		return Optional.ofNullable(server.get(oAuthServer));
 	}
 
 }

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthPropertyHandler.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthPropertyHandler.java
@@ -1,7 +1,6 @@
 package com.jpaplayground.global.oauth;
 
 import java.util.Map;
-import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -16,8 +15,8 @@ public class OAuthPropertyHandler {
 	/* TODO : yml 파일의 "github"가 자동으로 Enum으로 매핑된다. HOW? */
 	private final Map<OAuthServer, OAuthProperties> server;
 
-	public Optional<OAuthProperties> getProperties(OAuthServer oAuthServer) {
-		return Optional.ofNullable(server.get(oAuthServer));
+	public OAuthProperties getProperties(OAuthServer oAuthServer) {
+		return server.get(oAuthServer);
 	}
 
 }

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthServer.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthServer.java
@@ -1,0 +1,8 @@
+package com.jpaplayground.global.oauth;
+
+public enum OAuthServer {
+	GITHUB,
+	KAKAO,
+	NAVER
+
+}

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthServer.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthServer.java
@@ -1,8 +1,27 @@
 package com.jpaplayground.global.oauth;
 
+import java.util.Arrays;
+
 public enum OAuthServer {
-	GITHUB,
-	KAKAO,
-	NAVER
+	GITHUB("github"),
+	KAKAO("kakao"),
+	NAVER("naver");
+
+	private final String name;
+
+	OAuthServer(String name) {
+		this.name = name;
+	}
+
+	private boolean hasName(String name) {
+		return this.name.equals(name);
+	}
+
+	public static OAuthServer getOAuthServer(String server) {
+		return Arrays.stream(OAuthServer.values())
+			.filter(oAuthServer -> oAuthServer.hasName(server))
+			.findFirst()
+			.orElseThrow(OAuthServerNotFoundException::new);
+	}
 
 }

--- a/src/main/java/com/jpaplayground/global/oauth/OAuthServerNotFoundException.java
+++ b/src/main/java/com/jpaplayground/global/oauth/OAuthServerNotFoundException.java
@@ -1,0 +1,11 @@
+package com.jpaplayground.global.oauth;
+
+import com.jpaplayground.global.exception.ErrorCode;
+import com.jpaplayground.global.exception.NotFoundException;
+
+public class OAuthServerNotFoundException extends NotFoundException {
+
+	public OAuthServerNotFoundException() {
+		super(ErrorCode.OAUTH_SERVER_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/jpaplayground/global/oauth/dto/GitHubAccessToken.java
+++ b/src/main/java/com/jpaplayground/global/oauth/dto/GitHubAccessToken.java
@@ -1,0 +1,14 @@
+package com.jpaplayground.global.oauth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GitHubAccessToken {
+
+	private String accessToken;
+	private String scope;
+	private String tokenType;
+
+}

--- a/src/main/java/com/jpaplayground/global/oauth/dto/GitHubAccessToken.java
+++ b/src/main/java/com/jpaplayground/global/oauth/dto/GitHubAccessToken.java
@@ -1,14 +1,20 @@
 package com.jpaplayground.global.oauth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class GitHubAccessToken {
 
+	@JsonProperty(value = "access_token")
 	private String accessToken;
 	private String scope;
+	@JsonProperty(value = "token_type")
 	private String tokenType;
 
 }

--- a/src/main/java/com/jpaplayground/global/oauth/dto/GitHubUserInfo.java
+++ b/src/main/java/com/jpaplayground/global/oauth/dto/GitHubUserInfo.java
@@ -1,0 +1,23 @@
+package com.jpaplayground.global.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jpaplayground.global.member.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class GitHubUserInfo implements OAuthUserInfo {
+
+	@JsonProperty(value = "login")
+	private String account;
+	private String name;
+	private String email;
+
+	@Override
+	public Member toEntity() {
+		return Member.of(account, name, email);
+	}
+}

--- a/src/main/java/com/jpaplayground/global/oauth/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/com/jpaplayground/global/oauth/dto/GithubAccessTokenRequest.java
@@ -1,16 +1,16 @@
 package com.jpaplayground.global.oauth.dto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jpaplayground.global.oauth.OAuthProperties;
 import lombok.Getter;
 
 @Getter
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GithubAccessTokenRequest {
 
 	private final String code;
+	@JsonProperty(value = "client_id")
 	private final String clientId;
+	@JsonProperty(value = "client_secret")
 	private final String clientSecret;
 
 	public GithubAccessTokenRequest(String code, OAuthProperties properties) {

--- a/src/main/java/com/jpaplayground/global/oauth/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/com/jpaplayground/global/oauth/dto/GithubAccessTokenRequest.java
@@ -1,0 +1,21 @@
+package com.jpaplayground.global.oauth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.jpaplayground.global.oauth.OAuthProperties;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GithubAccessTokenRequest {
+
+	private final String code;
+	private final String clientId;
+	private final String clientSecret;
+
+	public GithubAccessTokenRequest(String code, OAuthProperties properties) {
+		this.code = code;
+		this.clientId = properties.getClientId();
+		this.clientSecret = properties.getClientSecret();
+	}
+}

--- a/src/main/java/com/jpaplayground/global/oauth/dto/OAuthUserInfo.java
+++ b/src/main/java/com/jpaplayground/global/oauth/dto/OAuthUserInfo.java
@@ -1,0 +1,16 @@
+package com.jpaplayground.global.oauth.dto;
+
+import com.jpaplayground.global.member.Member;
+
+public interface OAuthUserInfo {
+
+	String getAccount();
+
+	String getName();
+
+	String getEmail();
+
+	String toString();
+
+	Member toEntity();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import: classpath:oauth.yml
+
   datasource:
     # MODE=MySQL;IGNORECASE=TRUE 설정 필요한가?
     url: jdbc:h2:mem:mydb

--- a/src/test/java/com/jpaplayground/TestData.java
+++ b/src/test/java/com/jpaplayground/TestData.java
@@ -1,0 +1,48 @@
+package com.jpaplayground;
+
+import com.jpaplayground.domain.product.Product;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TestData {
+
+	public static final List<Product> allProducts;
+	public static final List<Product> deletedProducts;
+	public static final List<Product> notDeletedProducts;
+
+	static {
+		allProducts = buildAllProducts();
+		deletedProducts = buildDeletedProducts();
+		notDeletedProducts = buildNotDeletedProducts();
+	}
+
+	private static List<Product> buildAllProducts() {
+		Product deletedProduct1 = Product.of("노트북파우치", 10000);
+		Product deletedProduct2 = Product.of("와플기계", 30000);
+		Product deletedProduct3 = Product.of("한무무", 100000);
+		deletedProduct1.delete();
+		deletedProduct2.delete();
+		deletedProduct3.delete();
+
+		return List.of(
+			deletedProduct1,
+			Product.of("가습기", 15000),
+			Product.of("맥북에어M1", 900000),
+			Product.of("버티컬마우스", 20000),
+			deletedProduct2,
+			Product.of("쉐이커통", 5000),
+			Product.of("클라이밍초크", 10000),
+			Product.of("닌텐도스위치", 250000),
+			Product.of("젤다의전설", 35000),
+			deletedProduct3
+		);
+	}
+
+	private static List<Product> buildDeletedProducts() {
+		return allProducts.stream().filter(Product::getDeleted).collect(Collectors.toList());
+	}
+
+	private static List<Product> buildNotDeletedProducts() {
+		return allProducts.stream().filter(product -> !product.getDeleted()).collect(Collectors.toList());
+	}
+}

--- a/src/test/java/com/jpaplayground/conversation/ConversationServiceUnitTest.java
+++ b/src/test/java/com/jpaplayground/conversation/ConversationServiceUnitTest.java
@@ -1,12 +1,5 @@
 package com.jpaplayground.conversation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
 import com.jpaplayground.domain.conversation.Conversation;
 import com.jpaplayground.domain.conversation.ConversationRepository;
 import com.jpaplayground.domain.conversation.ConversationService;
@@ -17,8 +10,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.times;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -43,17 +41,16 @@ class ConversationServiceUnitTest {
 		Product product = Product.of("제품", 10_000);
 
 		Conversation conversation = Conversation.of(request.getContent(), product);
-		given(productRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(product));
+		given(productRepository.findById(any(Long.class))).willReturn(
+			Optional.ofNullable(product)); // Stubbing. 테스트 진행을 위해 사용
 		given(conversationRepository.save(any(Conversation.class))).willReturn(conversation);
 
 		// when
 		Conversation savedConversation = service.save(request);
 
 		// then
-		then(productRepository).should(times(1)).findById(request.getProductId());
+		then(productRepository).should(times(1)).findById(request.getProductId()); // 행동 검증. verify. Mock
 		then(conversationRepository).should(times(1)).save(refEq(conversation));
-
-		assertThat(savedConversation.getContent()).isEqualTo(request.getContent());
 	}
 
 }

--- a/src/test/java/com/jpaplayground/product/ProductControllerTest.java
+++ b/src/test/java/com/jpaplayground/product/ProductControllerTest.java
@@ -1,23 +1,24 @@
 package com.jpaplayground.product;
 
-import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jpaplayground.domain.product.ProductController;
 import com.jpaplayground.domain.product.ProductService;
 import com.jpaplayground.domain.product.dto.ProductCreateRequest;
+import com.jpaplayground.global.oauth.OAuthPropertyHandler;
+import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * <a href="https://reflectoring.io/spring-boot-web-controller-test/">
@@ -29,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
  * <br><a href="https://github.com/honeySleepr/JpaPlayground/pull/5#issuecomment-1250048799">관련 PR 피드백</a>
  */
 @WebMvcTest(ProductController.class)
+@EnableConfigurationProperties(OAuthPropertyHandler.class)
 class ProductControllerTest {
 
 	@Autowired

--- a/src/test/java/com/jpaplayground/product/ProductServiceIntegrationTest.java
+++ b/src/test/java/com/jpaplayground/product/ProductServiceIntegrationTest.java
@@ -2,8 +2,8 @@ package com.jpaplayground.product;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.jpaplayground.TestData;
 import com.jpaplayground.domain.product.Product;
 import com.jpaplayground.domain.product.ProductRepository;
 import com.jpaplayground.domain.product.ProductService;
@@ -11,7 +11,7 @@ import com.jpaplayground.domain.product.dto.ProductCreateRequest;
 import com.jpaplayground.domain.product.dto.ProductResponse;
 import com.jpaplayground.domain.product.exception.ProductNotFoundException;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,49 +20,52 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.test.context.jdbc.Sql;
 
 /**
  * Service 단에서 통합테스트와 단위테스트를 둘다 하는건 의미가 없는 것 같아서 단위테스트만 해볼 예정이었으나, 단위 테스트로 뭘 어떻게 테스트해야하는지 모르겠어서 다시 통합테스트로 후퇴
  */
 @SpringBootTest
+@Sql(value = "classpath:testdata.sql") /* 통합테스트에서는 테스트용 DB data 사용*/
 class ProductServiceIntegrationTest {
 
-	private static final String ERRORCODE = "errorCode";
-
+	static List<Product> allProducts;
+	static List<Product> deletedProducts;
+	static List<Product> notDeletedProducts;
 	@Autowired
 	ProductService productService;
 	@Autowired
 	ProductRepository productRepository;
+
+	@BeforeAll
+	static void init() {
+		allProducts = TestData.allProducts;
+		deletedProducts = TestData.deletedProducts;
+		notDeletedProducts = TestData.notDeletedProducts;
+	}
 
 	/**
 	 * 테스트에서 @Transactional을 쓰지 않기 위함 ->
 	 * <a href="https://tecoble.techcourse.co.kr/post/2020-08-31-jpa-transaction-test/">테스트 코드에서 @Transactional
 	 * 주의하기</a>
 	 */
-	@AfterEach
-	void tearDown() {
-		productRepository.deleteAll();
-	}
 
 	@Test
-	@DisplayName("제품을 등록하면 db에 제품이 저장된다")
+	@DisplayName("제품을 등록하면 제품이 저장된다")
 	void save() {
-
 		// given
 		ProductCreateRequest request = new ProductCreateRequest("한무무", 149_000);
-		int initialSize = productRepository.findAll().size();
+		int size = allProducts.size();
 
 		// when
 		Product savedProduct = productService.save(request);
 
 		// then
+		/* TODO: 테스트 결과를 검증할 때는 어쩔 수 없이 repository의 메서드를 쓰는게 맞는지 */
 		Product foundProduct = productRepository.findById(savedProduct.getId()).get();
-		assertAll(
-			() -> assertThat(foundProduct).usingRecursiveComparison()
-				.isEqualTo(savedProduct),
-			() -> assertThat(productRepository.findAll()).hasSize(initialSize + 1)
-		);
 
+		assertThat(foundProduct).usingRecursiveComparison().isEqualTo(savedProduct);
+		assertThat(productRepository.findAll()).hasSize(size + 1);
 	}
 
 	@Nested
@@ -73,9 +76,6 @@ class ProductServiceIntegrationTest {
 		@DisplayName("Paging이 적용된 제품 목록을 반환한다")
 		void findAll_paged() {
 			//given
-			for (int i = 1; i <= 20; i++) {
-				productRepository.save(Product.of(String.valueOf(i), 1000));
-			}
 			int page = 1;
 			int size = 3;
 			int offset = page * size;
@@ -89,28 +89,23 @@ class ProductServiceIntegrationTest {
 
 			assertThat(content.size()).isEqualTo(size);
 			for (int i = 0; i < size; i++) {
-				assertThat(content.get(i).getName()).isEqualTo(String.valueOf(i + offset + 1));
+				assertThat(content.get(i).getName()).isEqualTo(notDeletedProducts.get(i + offset).getName());
 			}
 		}
 
 		@Test
 		@DisplayName("삭제된 제품은 조회되지 않는다")
-		void findAll_not_deleted() {
+		void findAll_except_deleted() {
 			// given
-			Product product1 = Product.of("1", 1000);
-			product1.delete();
-			productRepository.save(product1);
-			productRepository.save(Product.of("2", 1000));
-			productRepository.save(Product.of("3", 1000));
-
-			int size = productRepository.findAll().size();
-			Pageable pageable = Pageable.ofSize(size);
+			int numberOfTotalProducts = allProducts.size();
+			int numberOfDeletedProducts = deletedProducts.size();
+			Pageable pageable = Pageable.ofSize(numberOfTotalProducts);
 
 			// when
 			Slice<ProductResponse> slice = productService.findAll(pageable);
 
 			// then
-			assertThat(slice.getNumberOfElements()).isEqualTo(size - 1);
+			assertThat(slice.getNumberOfElements()).isEqualTo(numberOfTotalProducts - numberOfDeletedProducts);
 		}
 
 	}
@@ -119,11 +114,9 @@ class ProductServiceIntegrationTest {
 	@DisplayName("존재하지 않는 product를 삭제하려고 하면 예외가 발생한다")
 	void delete_error() {
 		// given
-		List<Product> products = productRepository.findAll();
-		Long id = products.size() + 1L;
+		Long id = allProducts.size() + 100L;
 
 		// when
-
 		// then
 		assertThatThrownBy(() -> productService.delete(id)).isInstanceOf(ProductNotFoundException.class);
 	}

--- a/src/test/java/com/jpaplayground/product/ProductServiceIntegrationTest.java
+++ b/src/test/java/com/jpaplayground/product/ProductServiceIntegrationTest.java
@@ -1,8 +1,5 @@
 package com.jpaplayground.product;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.jpaplayground.TestData;
 import com.jpaplayground.domain.product.Product;
 import com.jpaplayground.domain.product.ProductRepository;
@@ -11,6 +8,8 @@ import com.jpaplayground.domain.product.dto.ProductCreateRequest;
 import com.jpaplayground.domain.product.dto.ProductResponse;
 import com.jpaplayground.domain.product.exception.ProductNotFoundException;
 import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +31,7 @@ class ProductServiceIntegrationTest {
 	static List<Product> allProducts;
 	static List<Product> deletedProducts;
 	static List<Product> notDeletedProducts;
+
 	@Autowired
 	ProductService productService;
 	@Autowired
@@ -49,6 +49,14 @@ class ProductServiceIntegrationTest {
 	 * <a href="https://tecoble.techcourse.co.kr/post/2020-08-31-jpa-transaction-test/">테스트 코드에서 @Transactional
 	 * 주의하기</a>
 	 */
+
+	@Test /* TestData 가 repository의 데이터와 일치하는지도 검사를 해야할 것 같다. 그런데 이러면 배꼽이 더 커지는 것 같다.. */
+	@DisplayName("testdata.sql로 삽입된 데이터와 TestData를 이용해 만든 데이터가 일치하는지 테스트한다")
+	void testdata_integrity_test() {
+		List<Product> savedProducts = productRepository.findAll();
+		savedProducts.forEach(product -> assertThat(product).usingRecursiveComparison().ignoringFields("id")
+			.isEqualTo(allProducts.get(savedProducts.indexOf(product))));
+	}
 
 	@Test
 	@DisplayName("제품을 등록하면 제품이 저장된다")

--- a/src/test/resources/testdata.sql
+++ b/src/test/resources/testdata.sql
@@ -1,0 +1,13 @@
+delete
+from product;
+insert into product(name, price, deleted)
+values ('노트북파우치', 10000, true),
+       ('가습기', 15000, false),
+       ('맥북에어M1', 900000, false),
+       ('버티컬마우스', 20000, false),
+       ('와플기계', 30000, true),
+       ('쉐이커통', 5000, false),
+       ('클라이밍초크', 10000, false),
+       ('닌텐도스위치', 250000, false),
+       ('젤다의전설', 35000, false),
+       ('한무무', 100000, true);


### PR DESCRIPTION
안녕하십니까~~~~ 저번 주에 코테니 이력서니 할 일이 너무 몰려 정신을 못차리는 바람에 PR을 못드렸습니다..🥲

이번 주도 진전은 많이 없지만, 테스트 관련 궁금증이 또 생겨서 아래에 질문 남기겠습니다.

## ⚒️ 중점적으로 구현한 내용

- OAuth 로그인을 위한 기반 작업 (issue tracker 때 아코형이 적용하셨던거랑 거의 같으나, 조금씩이라도 변화를 주기 위해 노력하였습니다)
  - 환경변수를 POJO로 매핑하기 위한 @ConfigurationPropertiesScan 적용
  - login 최초 요청을 Filter에서 잡아서 해당되는 Resource Server의 OAuth 로그인 페이지로 redirect 되도록 구현

- Github OAuth 로그인 구현 : UserInfo를 받아오는 단계 까지만 구현하였습니다. (추후 진행 예정)

## ❓ 질문

### 1. `@ConfigurationProperties`가 적용된 oAuthPropertyHandler 때문에  통합테스트가 터져버리는 문제

[(링크)](https://github.com/honeySleepr/JpaPlayground/pull/7/files#r985521151)


### 2. ProductServiceIntegrationTest 

해당 테스트에서 repository의 메서드에 대한 의존성을 없애기 위해 수정을 하였으나,
1. save() 같은 메서드를 테스트할 때는 값이 들어갔는지 확인할 때 결국 repository를 호출하여 사용해야하고, (즉, repository에 대한 의존성을 완전히 제거하지 못하고)
2. `TestData` 클래스의 더미데이터 와 `testdata.sql`의 데이터가 일치하는지도 검증해줘야하는 번거로움이 생겼습니다.

그래서 내린 결론은, Service 통합 테스트를 없애고 `service 단위 테스트` + `@DataJpaTest를 이용한 Repository test`로 나누는 게 낫겠다는 것인데,
리아코는 어떻게 생각하시는지 궁금합니다 🥺

---

급하지 않으니 느긋하게, 진짜 심심하실 때 봐주셔도됩니다
항상 감사드립니다🙇  